### PR TITLE
refactor(newContainer): 加強邏輯、可讀性

### DIFF
--- a/app/routes/stores/new/newContainer.tsx
+++ b/app/routes/stores/new/newContainer.tsx
@@ -1,55 +1,54 @@
 import { useState } from "react";
 import { Outlet } from "react-router";
+import * as z from "zod";
 
-type StoreFormData = {
-  step1: {
-    name: string;
-    phone: string;
-    address: string;
-  };
-  step2: {
-    description: string;
-    deliveryAvailable: boolean;
-    deliveryMinimum?: string | undefined;
-  };
+export const step1Schema = z.object({
+  name: z.string().min(1, "請輸入店名"),
+  phone: z
+    .string()
+    .min(1, "請輸入電話號碼")
+    .regex(/^09\d{8}$/, "請輸入以 09 開頭的 10 碼電話號碼"),
+  address: z.string(),
+});
+export type Step1Values = z.input<typeof step1Schema>;
+
+export const step2Schema = z
+  .object({
+    description: z.string(),
+    deliveryAvailable: z.boolean(),
+    deliveryMinimum: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.deliveryAvailable &&
+      (!data.deliveryMinimum || isNaN(Number(data.deliveryMinimum)))
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "外送低消請輸入數字",
+        path: ["deliveryMinimum"],
+      });
+    }
+  });
+export type Step2Values = z.infer<typeof step2Schema>;
+
+
+export type StoreNewContextType = {
+  // 狀態分開來，在使用時會比較容易分辨
+  // 用 null 來表示使用者尚未輸入資料
+  step1: Step1Values | null;
+  step2: Step2Values | null;
+  // setter 不允許 null，不存在這種情境
+  setStep1: (value: Step1Values) => void;
+  setStep2: (value: Step2Values) => void;
+  // 不需要 reset，因為離開這個流程的時候 newContainer 會被 unmount，狀態就已經被清空了
 };
 
-export type StoreNewContextType = [
-  StoreFormData, // 步驟一和步驟二資料
-  (value: StoreFormData | ((prev: StoreFormData) => StoreFormData)) => void, // 更新步驟一和步驟二資料
-  () => void, // 清空步驟一和步驟二資料
-];
-
 function newContainer() {
-  // formData 用來儲存步驟一和步驟二的資料，以便回一步時不會清掉步驟一和步驟二的資料
-  const [formData, setFormData] = useState<StoreFormData>({
-    step1: {
-      name: "",
-      phone: "",
-      address: "",
-    },
-    step2: {
-      description: "",
-      deliveryAvailable: false,
-      deliveryMinimum: "",
-    },
-  });
+  const [step1, setStep1] = useState<Step1Values | null>(null);
+  const [step2, setStep2] = useState<Step2Values | null>(null);
 
-  const handleReset = () => {
-    setFormData({
-      step1: {
-        name: "",
-        phone: "",
-        address: "",
-      },
-      step2: {
-        description: "",
-        deliveryAvailable: false,
-        deliveryMinimum: "",
-      },
-    });
-  };
-  return <Outlet context={[formData, setFormData, handleReset]} />;
+  return <Outlet context={{ step1, step2, setStep1, setStep2 }} />;
 }
 
 export default newContainer;

--- a/app/routes/stores/new/step1.tsx
+++ b/app/routes/stores/new/step1.tsx
@@ -1,37 +1,35 @@
-import type { StoreNewContextType } from "@/routes/stores/new/newContainer";
+import {
+  step1Schema,
+  type Step1Values,
+  type StoreNewContextType,
+} from "@/routes/stores/new/newContainer";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Form, Input } from "antd";
 import { Controller, useForm } from "react-hook-form";
 import { Link, useNavigate, useOutletContext } from "react-router";
-import * as z from "zod";
 const { TextArea } = Input;
 
-const step1Schema = z.object({
-  name: z.string().min(1, "請輸入店名"),
-  phone: z
-    .string()
-    .min(1, "請輸入電話號碼")
-    .regex(/^09\d{8}$/, "請輸入以 09 開頭的 10 碼電話號碼"),
-  address: z.string(),
-});
-
-type Step1Inputs = z.infer<typeof step1Schema>;
+const step1InitialValues: Step1Values = {
+  name: "",
+  phone: "",
+  address: "",
+};
 
 function step1() {
   let navigate = useNavigate();
-  const [formData, setFormData] = useOutletContext<StoreNewContextType>();
+  const { step1, setStep1 } = useOutletContext<StoreNewContextType>();
 
   const {
     handleSubmit,
     control,
     formState: { errors },
-  } = useForm<Step1Inputs>({
+  } = useForm({
     resolver: zodResolver(step1Schema),
-    defaultValues: formData.step1,
+    defaultValues: step1 ?? step1InitialValues,
   });
 
-  const submitForm = (data: Step1Inputs) => {
-    setFormData((prev)=>({...prev, step1:data})); // 將步驟一資料存到父組件 newContainer
+  const submitForm = (data: Step1Values) => {
+    setStep1(data); // 將步驟一資料存到父組件 newContainer
     navigate("/stores/new/step-2");
   };
 

--- a/app/routes/stores/new/step2.tsx
+++ b/app/routes/stores/new/step2.tsx
@@ -1,47 +1,38 @@
-import type { StoreNewContextType } from "@/routes/stores/new/newContainer";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button, Checkbox, Form, Input } from "antd";
 import { Controller, useForm } from "react-hook-form";
-import { Link, useNavigate, useOutletContext } from "react-router";
-import * as z from "zod";
+import { Link, Navigate, useNavigate, useOutletContext } from "react-router";
+import {
+  step2Schema,
+  type Step2Values,
+  type StoreNewContextType,
+} from "./newContainer";
 const { TextArea } = Input;
 
-const step2Schema = z
-  .object({
-    description: z.string(),
-    deliveryAvailable: z.boolean(),
-    deliveryMinimum: z.string().optional(),
-  })
-  .superRefine((data, ctx) => {
-    if (
-      data.deliveryAvailable &&
-      (!data.deliveryMinimum || isNaN(Number(data.deliveryMinimum)))
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message: "外送低消請輸入數字",
-        path: ["deliveryMinimum"],
-      });
-    }
-  });
-
-type Step2Inputs = z.infer<typeof step2Schema>;
+const step2InitialValues: Step2Values = {
+  description: "",
+  deliveryAvailable: false,
+  deliveryMinimum: "",
+};
 
 function step2() {
   let navigate = useNavigate();
-  const [formData, setFormData] = useOutletContext<StoreNewContextType>();
+  const { step1, step2, setStep2 } = useOutletContext<StoreNewContextType>();
+
+  // 正常流程是不太可能發生，但使用者確實能直接用網址進入此頁面
+  if (!step1) return <Navigate to="/stores/new/step-1" />;
 
   const {
     control,
     handleSubmit,
     formState: { errors },
-  } = useForm<Step2Inputs>({
+  } = useForm({
     resolver: zodResolver(step2Schema),
-    defaultValues: formData.step2, // 使用 store 的 step2Data 初始值
+    defaultValues: step2 ?? step2InitialValues,
   });
 
-  const submitForm = (data: Step2Inputs) => {
-    setFormData((prev) => ({ ...prev, step2: data })); // 將步驟二資料存到父組件 newContainer
+  const submitForm = (data: Step2Values) => {
+    setStep2(data); // 將步驟二資料存到父組件 newContainer
     navigate("/stores/new/step-3");
   };
 

--- a/app/routes/stores/new/step3.tsx
+++ b/app/routes/stores/new/step3.tsx
@@ -41,15 +41,15 @@ function step3() {
             <div className="flex-1 space-y-8 text-colorTextSecondary">
               <div className="flex items-baseline ">
                 <p className="w-24">店名</p>
-                <p className="flex-1">{step1?.name ?? ""}</p>
+                <p className="flex-1">{step1.name}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">電話</p>
-                <p className="flex-1">{step1?.phone ?? ""}</p>
+                <p className="flex-1">{step1.phone}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">地址</p>
-                <p className="flex-1">{step1?.address ?? ""}</p>
+                <p className="flex-1">{step1.address}</p>
               </div>
             </div>
           </div>
@@ -64,13 +64,13 @@ function step3() {
             <div className="flex-1 space-y-8 text-colorTextSecondary">
               <div className="flex items-baseline ">
                 <p className="w-24">店家描述</p>
-                <p className="flex-1">{step2?.description ?? ""}</p>
+                <p className="flex-1">{step2.description}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">外送服務</p>
                 <p className="flex-1">
-                  {step2?.deliveryAvailable
-                    ? `是 / 外送低消 ${step2.deliveryMinimum ?? ""}`
+                  {step2.deliveryAvailable
+                    ? `是 / 外送低消 ${step2.deliveryMinimum}`
                     : "否"}
                 </p>
               </div>

--- a/app/routes/stores/new/step3.tsx
+++ b/app/routes/stores/new/step3.tsx
@@ -1,25 +1,28 @@
-import { createStore } from "@/api/stores/createStore";
+import { createStore, type CreateStorePayload } from "@/api/stores/createStore";
 import type { StoreNewContextType } from "@/routes/stores/new/newContainer";
 import { Button } from "antd";
-import { Link, useNavigate, useOutletContext } from "react-router";
+import { Link, Navigate, useNavigate, useOutletContext } from "react-router";
 
 function step3() {
   let navigate = useNavigate();
-  const [formData, setFormData, handleReset] = useOutletContext<StoreNewContextType>();
+  const { step1, step2 } = useOutletContext<StoreNewContextType>();
+
+  // 正常流程是不太可能發生，但使用者確實能直接用網址進入此頁面
+  if (!step1) return <Navigate to="/stores/new/step-1" />;
+  if (!step2) return <Navigate to="/stores/new/step-2" />;
 
   const submitForm = async () => {
     // 組合要給後端的資料
-    const payload = {
-      ...formData.step1,
-      ...formData.step2,
-      deliveryMinimum: Number(formData.step2.deliveryMinimum) || 0,
+    const payload: CreateStorePayload = {
+      ...step1,
+      ...step2,
+      deliveryMinimum: Number(step2.deliveryMinimum) || 0,
       deliveryFee: 0,
     };
 
     const data = await createStore(payload);
 
     if (data) {
-      handleReset(); // 清空所有表單資料
       navigate("/stores");
     }
   };
@@ -38,15 +41,15 @@ function step3() {
             <div className="flex-1 space-y-8 text-colorTextSecondary">
               <div className="flex items-baseline ">
                 <p className="w-24">店名</p>
-                <p className="flex-1">{formData.step1.name}</p>
+                <p className="flex-1">{step1?.name ?? ""}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">電話</p>
-                <p className="flex-1">{formData.step1.phone}</p>
+                <p className="flex-1">{step1?.phone ?? ""}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">地址</p>
-                <p className="flex-1">{formData.step1.address}</p>
+                <p className="flex-1">{step1?.address ?? ""}</p>
               </div>
             </div>
           </div>
@@ -61,13 +64,13 @@ function step3() {
             <div className="flex-1 space-y-8 text-colorTextSecondary">
               <div className="flex items-baseline ">
                 <p className="w-24">店家描述</p>
-                <p className="flex-1">{formData.step2.description}</p>
+                <p className="flex-1">{step2?.description ?? ""}</p>
               </div>
               <div className="flex items-baseline">
                 <p className="w-24">外送服務</p>
                 <p className="flex-1">
-                  {formData.step2.deliveryAvailable
-                    ? `是 / 外送低消 ${formData.step2.deliveryMinimum}`
+                  {step2?.deliveryAvailable
+                    ? `是 / 外送低消 ${step2.deliveryMinimum ?? ""}`
                     : "否"}
                 </p>
               </div>


### PR DESCRIPTION
## 改了啥

狀態、邏輯盡量集中管理在 [app/routes/stores/new/newContainer.tsx]。
[app/routes/stores/new/step1.tsx], [app/routes/stores/new/step2.tsx], [app/routes/stores/new/step3.tsx] 只是跟著已經理好的邏輯去寫出介面讓使用者使用。
不過這個 multi-step form 的內容非常自由，所以實際看不太出來集中狀態管理的好處在哪。

### 將 `step1`, `step2` 狀態獨立

比起把所有狀態寫在一起，分開來會使得使用到的地方比較明確在處理什麼

https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/newContainer.tsx#L48-L51

### 以 `null` 做初始值區分意圖

[app/routes/stores/new/newContainer.tsx] 只負責存放狀態

https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/newContainer.tsx#L48

[app/routes/stores/new/step1.tsx] 串接初始狀態

https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step2.tsx#L12-L16
https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step1.tsx#L28

### `step1` 處理使用者操作並回存狀態

https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step1.tsx#L31-L34

 [app/routes/stores/new/newContainer.tsx]:https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/newContainer.tsx
[app/routes/stores/new/step1.tsx]:https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step1.tsx
[app/routes/stores/new/step2.tsx]:https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step2.tsx
[app/routes/stores/new/step3.tsx]:https://github.com/bady55358yw/bento/blob/7bda92c85b23e9452dd1950e4c1a93a7b0b95e72/app/routes/stores/new/step3.tsx